### PR TITLE
Iteration7 improve edit queue

### DIFF
--- a/backend/my_queue/models.py
+++ b/backend/my_queue/models.py
@@ -54,7 +54,7 @@ class Entry(models.Model):
             self.tracking_code = new_tracking_code
 
         if not self.name:
-            today = timezone.now().date()
+            today = timezone.localtime(timezone.now()).date()
             queue_entries_today = (
                 Entry.objects.filter(queue=self.queue, time_in__date=today).count() + 1
             )

--- a/frontend/app/business/AddEntry.tsx
+++ b/frontend/app/business/AddEntry.tsx
@@ -27,8 +27,9 @@ interface EntryData {
   tracking_code: string;
 }
 
+
 const AddEntry: React.FC<AddEntryProps>  = ({ queue }) => {
-  const [selectedQueue, setSelectedQueue] = useState(queue[0]?.id || -1);
+  const [selectedQueue, setSelectedQueue] = useState(queue[0]?.id || null);
   const [trackingCode, setTrackingCode] = useState(null);
   const [entryData, setEntryData] = useState<EntryData | null>(null);
   const [src, setSrc] = useState<string | null>(null);
@@ -38,10 +39,10 @@ const AddEntry: React.FC<AddEntryProps>  = ({ queue }) => {
       console.log("Updated tracking code:", trackingCode);
       generate();
     }
-  });
+  }, [trackingCode]);
 
   useEffect(() => {
-    if (queue.length == 1 && !selectedQueue) {
+    if (!selectedQueue) {
       setSelectedQueue(queue[0]?.id);
     }
   }, [queue]);
@@ -165,12 +166,12 @@ const AddEntry: React.FC<AddEntryProps>  = ({ queue }) => {
                   </div>
                 </div>
                 <div className="flex justify-end">
-                <button
-                  className="btn h-12 w-20 mr-2"
-                  onClick={() => reactToPrintFn && reactToPrintFn()}
-                >
-                  <LocalPrintshopIcon style={{ fontSize: 30 }} />
-                </button>                
+                  <button
+                    className="btn h-12 w-20 mr-2"
+                    onClick={() => reactToPrintFn && reactToPrintFn()}
+                  >
+                    <LocalPrintshopIcon style={{ fontSize: 30 }} />
+                  </button>
                 </div>
               </div>
                   ) : (

--- a/frontend/app/business/AddEntry.tsx
+++ b/frontend/app/business/AddEntry.tsx
@@ -24,8 +24,8 @@ const AddEntry = ({ queue }) => {
   }, [trackingCode]);
 
   useEffect(() => {
-    if (queue.length > 0) {
-      setSelectedQueue(queue[0].id);
+    if (queue.length === 1 && !selectedQueue) {
+      setSelectedQueue(queue[0]?.id);
     }
   }, [queue]);
   

--- a/frontend/app/business/AddEntry.tsx
+++ b/frontend/app/business/AddEntry.tsx
@@ -24,7 +24,7 @@ const AddEntry = ({ queue }) => {
   }, [trackingCode]);
 
   useEffect(() => {
-    if (queue.length === 1 && !selectedQueue) {
+    if (queue.length == 1 && !selectedQueue) {
       setSelectedQueue(queue[0]?.id);
     }
   }, [queue]);

--- a/frontend/app/business/EditQueue.tsx
+++ b/frontend/app/business/EditQueue.tsx
@@ -1,21 +1,27 @@
 'use client'
 
-import { fetchData } from 'next-auth/client/_utils';
 import React from 'react'
 import { useState, useEffect } from 'react';
 import { mutate } from 'swr';
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
-import PreviewIcon from '@mui/icons-material/Preview';
-import Preview from './Preview';
 
 const BUSINESS_QUEUES_API_URL = "/api/business/queues/";
 const QUEUE_API_URL = "/api/queue/";
 
-const EditQueue = ({queue}) => {
-  const [QueueId, setQueueId] = useState('');
+interface Queue {
+  id: number; 
+  name: string;
+  prefix: string;
+}
+
+interface EditQueueProps {
+  queue: Queue;
+}
+
+const EditQueue: React.FC<EditQueueProps> = ({queue}) => {
+  const [QueueId, setQueueId] = useState(-1);
   const [editedQueue, setEditedQueue] = useState('');
   const [editedAlphabet, setEditedAlphabet] = useState('');
-  const [isModalOpen, setIsModalOpen] = useState(false);
   const [isExplanation, setIsExplanation] = useState(false)
   const [isPrefix, setIsPrefix] = useState(false)
 
@@ -24,28 +30,28 @@ const EditQueue = ({queue}) => {
     setQueueId(queue.id);
   }, [queue]);
 
-  const handleQueueChange = (event) => {
+  const handleQueueChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     console.log(QueueId, " ChangeQueue")
     setEditedQueue(event.target.value);
   }
 
-  const handleAlphabetChange = (event) => {
+  const handleAlphabetChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setEditedAlphabet(event.target.value);
   }
 
-  const handleAddClick = (queueID) => {
-    if (editedQueue && (editedAlphabet || !isPrefix)) {
-      handleSubmit(parseInt(QueueId, 10));
-      console.log('New Queue:', editedQueue);
-      console.log('New Alphabet', editedAlphabet);
-      closeModal(QueueId);
-    }
-    else {
-      console.log('No queue added');
-    }
+  const handleAddClick = () => {
+  if (editedQueue && (editedAlphabet || !isPrefix)) {
+    handleSubmit(QueueId);
+    console.log('New Queue:', editedQueue);
+    console.log('New Alphabet', editedAlphabet);
+    closeModal(QueueId);
   }
+  else {
+    console.log('No queue added');
+  }
+}
 
-  const openModal = async (queueId) => {
+  const openModal = async (queueId: number) => {
     setQueueId(queueId);
 
     try {
@@ -72,27 +78,23 @@ const EditQueue = ({queue}) => {
     } catch (error) {
       console.log("Error fetching queue data:", error);
     }
-    setIsModalOpen(true);
-    const modal = document.getElementById(QueueId);
+    const modal = document.getElementById(QueueId.toString()) as HTMLDialogElement;
     if (modal) {
       modal.showModal();
     }
   };
 
 
-  const closeModal = (QueueId) => {
-    setIsModalOpen(false);
+  const closeModal = (QueueId: number) => {
     setEditedQueue('');
     setEditedAlphabet('');
-    const modal = document.getElementById(QueueId);
+    const modal = document.getElementById(QueueId.toString()) as HTMLDialogElement;
     if (modal) {
       modal.close();
     }
   }
 
-
   const handleSubmit = async (queueId: number) => {
-  const newPrefix = isPrefix ? editedAlphabet : '';
     try {
       const response = await fetch(`/api/queue/${queueId}`, {
         method: "PUT",
@@ -101,7 +103,7 @@ const EditQueue = ({queue}) => {
         },
         body: JSON.stringify({
           name: editedQueue,
-          prefix: newPrefix
+          prefix: editedAlphabet
         })
       })
 
@@ -132,7 +134,6 @@ const EditQueue = ({queue}) => {
         console.log("Failed to delete queue")
         return
       }
-      const data = await response.json()
       mutate(BUSINESS_QUEUES_API_URL);
     } catch (error) {
       console.log("Error save delete queue:", error)
@@ -150,7 +151,7 @@ const EditQueue = ({queue}) => {
 
   return (
     <>
-        <dialog id={QueueId} className="modal">
+        <dialog id={QueueId.toString()} className="modal">
         <div className="modal-box">
             <form method="dialog">
             <button className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2" >

--- a/frontend/app/business/EditQueue.tsx
+++ b/frontend/app/business/EditQueue.tsx
@@ -34,7 +34,7 @@ const EditQueue = ({queue}) => {
   }
 
   const handleAddClick = (queueID) => {
-    if (editedQueue && editedAlphabet) {
+    if (editedQueue && (editedAlphabet || !isPrefix)) {
       handleSubmit(parseInt(QueueId, 10));
       console.log('New Queue:', editedQueue);
       console.log('New Alphabet', editedAlphabet);
@@ -90,15 +90,9 @@ const EditQueue = ({queue}) => {
     }
   }
 
-  const handleEditedQueue = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    setEditedQueue(event.target.value);
-  }
-
-  const handleEditedAlphabet = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    setEditedAlphabet(event.target.value);
-  }
 
   const handleSubmit = async (queueId: number) => {
+  const newPrefix = isPrefix ? editedAlphabet : '';
     try {
       const response = await fetch(`/api/queue/${queueId}`, {
         method: "PUT",
@@ -107,7 +101,7 @@ const EditQueue = ({queue}) => {
         },
         body: JSON.stringify({
           name: editedQueue,
-          prefix: editedAlphabet
+          prefix: newPrefix
         })
       })
 


### PR DESCRIPTION
### Description
Enhance the edit queue functionality to allow business owners to modify queues without requiring a prefix.

### Checklist:
- [x] Enable business owners to edit queues without specifying a prefix.
- [x] Fix the bug preventing entries from being added to the queue after it is edited.


### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please specify)